### PR TITLE
Added link for Slack channel:#certifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ If you see any errors with the document, please open an [issue](https://github.c
 
 CNCF encourages training companies to align their offerings to cover the contents of the curriculum. Training [partners](https://www.cncf.io/certification/training/) can purchase coupons for the CKA exam at a wholesale price to offer at the end of their training.
 
-If you have any queries regarding certifications, please use the following Slack channel link:[#certifications](https://cloud-native.slack.com/archives/CLQT6RZAM)
+If you have any queries regarding certifications, please use the following Slack channel link: [#certifications](https://cloud-native.slack.com/archives/CLQT6RZAM)
 
 The Curriculum is available under the [CC-BY 4.0+ License](https://creativecommons.org/licenses/by/4.0/).

--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ If you see any errors with the document, please open an [issue](https://github.c
 
 CNCF encourages training companies to align their offerings to cover the contents of the curriculum. Training [partners](https://www.cncf.io/certification/training/) can purchase coupons for the CKA exam at a wholesale price to offer at the end of their training.
 
+If you have any queries regarding certifications, please use the following Slack channel link:[#certifications](https://cloud-native.slack.com/archives/CLQT6RZAM)
+
 The Curriculum is available under the [CC-BY 4.0+ License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
For any queries regarding certifications, **slack channel link** for **certifications** is **added**.