### PR TITLE
Add CBA in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is the latest version of the curriculum for the following CNCF exams:
 * Certified Kubernetes Security Specialist (CKS)
 * Certified GitOps Associate (CGOA)
 * Certified Argo Project Associate (CAPA)
+* Certified Backstage Associate (CBA)
 * Cilium Certified Associate (CCA)
 * Istio Certified Associate (ICA)
 * Kubernetes and Cloud Native Associate (KCNA)


### PR DESCRIPTION
CBA was not mentioned in the README making it harder for people to choose which curriculum file to pick for CBA.

Not aware of any specific order being followed here so just put it at the end of Certified Argo.