### PR TITLE
Remove retired KubeAcademy link from KCNA resources

### DIFF
--- a/kcna/README.md
+++ b/kcna/README.md
@@ -19,7 +19,6 @@ To help you prepare for the certification, we recommend these materials and cour
 * https://www.edx.org/course/introduction-to-cloud-infrastructure-technologies
 * https://www.edx.org/course/introduction-to-kubernetes
 * https://www.edx.org/course/introduction-to-kubernetes-on-edge-with-k3s
-* https://kube.academy
 * https://www.edx.org/course/introduction-to-linux
 * https://civo.com/academy
 * [KCNA Course Overview](https://youtu.be/iGkFHB1kFZ0)


### PR DESCRIPTION
Title: Remove retired KubeAcademy link from KCNA resources

Type of PR: Documentation

Purpose of this PR:
KubeAcademy was officially retired on January 1, 2026. This PR removes the obsolete KubeAcademy link from the KCNA (Kubernetes and Cloud Native Associate) resource list to prevent users from being redirected to inactive or unavailable content.

Keeping the resource list up to date ensures learners have access only to valid, maintained, and officially supported study materials.

Changes:
- Removed the retired KubeAcademy link from the KCNA resources section.
- Verified that no additional references to KubeAcademy remain in the documentation.

Fixes:
- #98

I have tested the changes: Yes
- Confirmed documentation builds/rendering remain unaffected.
- Verified no broken formatting or unintended changes were introduced.
